### PR TITLE
Add filters for article id, title and url

### DIFF
--- a/livefyre-apps/apps/comments/src/display/LFAPPS_Comments_Display.php
+++ b/livefyre-apps/apps/comments/src/display/LFAPPS_Comments_Display.php
@@ -66,9 +66,9 @@ class LFAPPS_Comments_Display {
             $siteKey = Livefyre_Apps::get_option( 'livefyre_site_key' );
             $network_key = Livefyre_Apps::get_option( 'livefyre_domain_key', '');
             $post = get_post();
-            $articleId = get_the_ID();
-            $title = get_the_title($articleId);
-            $url = get_permalink($articleId);
+            $articleId = sanitize_text_field( apply_filter( 'livefyre_article_id', get_the_ID() ) );
+            $title = sanitize_text_field( apply_filter( 'livefyre_article_title', get_the_title( $articleId ), get_the_ID() ) );
+            $url = sanitize_text_field( apply_filter(' livefyre_article_url', get_permalink( $articleId ), get_the_ID() ) );
             $tags = array();
             $posttags = get_the_tags( $wp_query->post->ID );
             if ( $posttags ) {


### PR DESCRIPTION
We are using Livefyre Apps WordPress plugin in a WordPress VIP site and we have migrated content from a non WordPress system.

Currently there is no way for us to map the old article id with the new article id. If the three filters are added then it would be possible for us to override the default `get_the_ID()` and use the id from the old site.

I think these filters would be useful to anyone who wants to override the ids. Would appreciate if this get's merged. Thanks.