### PR TITLE
Avoid a fatal error when the Livefyre HTTP API request returns an error.

### DIFF
--- a/apps/comments/views/comments-template.php
+++ b/apps/comments/views/comments-template.php
@@ -16,7 +16,7 @@ if ( LFAPPS_Comments_Display::livefyre_show_comments() ) {
     $lfHttp = new LFAPPS_Http_Extension();
     $result = $lfHttp->request( $url );
     $cached_html = '';
-    if ( $result['response']['code'] == 200 ){
+    if ( ! is_wp_error( $result ) && $result['response']['code'] == 200 ){
         $cached_html = $result['body'];
         $cached_html = preg_replace( '(<script>[\w\W]*<\/script>)', '', $cached_html );
     }


### PR DESCRIPTION
If the Livefyre HTTP API request in the comments template file returns a `WP_Error`, it results in a fatal error because the response code check below it assumes the response is an array. This fixes that.

<img width="633" alt="screenshot 2016-03-09 11 26 42" src="https://cloud.githubusercontent.com/assets/208434/13633968/864075ca-e5ea-11e5-8713-c43c6b6a27f1.png">

/cc @simonwheatley