### PR TITLE
Replacing file_exists check by function exists

### DIFF
--- a/libs/php/LFAPPS_Http_Extension.php
+++ b/libs/php/LFAPPS_Http_Extension.php
@@ -13,7 +13,7 @@ class LFAPPS_Http_Extension {
      *
      */
     public function request( $url, $args = array() ) {
-        if(file_exists(LFAPPS__PLUGIN_PATH . '/../vip-init.php' )) {
+        if( function_exists( 'vip_safe_wp_remote_get' ) ) {
             if ( isset( $args[ 'data' ] ) ) {
                 $args[ 'body' ] = $args[ 'data' ];
                 unset( $args[ 'data' ] );


### PR DESCRIPTION
In order to properly use `wpcom_vip_*` function in `LFAPPS_Http_Extension::request` method on VIP Go platform, whether the vip-init.php file does not exists, but the `wpcom_vip_*` specific function does, we need to use different check than `function_exists` since it always fails.

This commit is fixing #113 by replacing the `file_exists` check by `function_exists`